### PR TITLE
feat: support for transparent colorschemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ supply `bg` in the config. To figure out which value you should use for `bg`, te
 following command:
 
 ```vim
-lua vim.notify(vim.inspect(vim.api.nvim_get_hl(0, { name = "Normal" }).bg))
+hi Normal
 ```
 
 ## 🤔 Motivation

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To change the defaults you can change any of the following values:
 ---@field depth number -- De depths of changing colors. Defaults to 4. After this the colors reset. Note that the first color is taken from your "Normal" highlight so a 4 is 3 new colors.
 ---@field automatic boolean -- Automatically turns this on when treesitter finds a parser for the current file.
 ---@field colors string [] | nil -- A list of colors to use instead. If this is set percent and depth are not taken into account.
+---@field bg string? -- Set this if block.nvim cannot automatically find your background color.
 
     require("block").setup({
         percent = 0.8,
@@ -38,8 +39,18 @@ To change the defaults you can change any of the following values:
 --            "#ff0000"
 --            "#00ff00"
 --            "#0000ff"
---        }
+--        },
+        bg = nil,
     })
+```
+
+### 🔧 Troubleshooting
+If block.nvim cannot determine your background color, for instance if you're using a transparent colorscheme, you must manually
+supply `bg` in the config. To figure out which value you should use for `bg`, temporarily turn off transparency and run the
+following command:
+
+```vim
+lua vim.notify(vim.inspect(vim.api.nvim_get_hl(0, { name = "Normal" }).bg))
 ```
 
 ## 🤔 Motivation

--- a/lua/block/util.lua
+++ b/lua/block/util.lua
@@ -26,14 +26,13 @@ end
 
 function M.get_bg_color()
     local normal_color = api.nvim_get_hl(0, { name = "Normal" })
-    return normal_color.bg
+    return normal_color.bg and string.format("#%06X", normal_color.bg)
 end
 
 function M.create_highlights_from_depth(depth, percent, bg)
-    local hex_color = string.format("#%06X", bg)
     for i = 0, depth do
-        M.hl(i, hex_color)
-        hex_color = darken_hex_color(hex_color, percent)
+        M.hl(i, bg)
+        bg = darken_hex_color(bg, percent)
     end
 end
 

--- a/lua/block/util.lua
+++ b/lua/block/util.lua
@@ -24,16 +24,17 @@ function M.hl(i, c)
     vim.cmd('highlight Bloc' .. i .. ' guibg=' .. c)
 end
 
-function M.create_highlights_from_depth(depth, percent)
-    vim.defer_fn(function() -- Getting the hl before vim loads throws an error
-        local normal_color = api.nvim_get_hl(0, { name = "Normal" })
-        local bg           = normal_color.bg
-        local hex_color    = string.format("#%06X", bg)
-        for i = 0, depth do
-            M.hl(i, hex_color)
-            hex_color = darken_hex_color(hex_color, percent)
-        end
-    end, 0)
+function M.get_bg_color()
+    local normal_color = api.nvim_get_hl(0, { name = "Normal" })
+    return normal_color.bg
+end
+
+function M.create_highlights_from_depth(depth, percent, bg)
+    local hex_color = string.format("#%06X", bg)
+    for i = 0, depth do
+        M.hl(i, hex_color)
+        hex_color = darken_hex_color(hex_color, percent)
+    end
 end
 
 return M


### PR DESCRIPTION
Since `guibg` isn't set for `Normal` in transparent colorschemes, the user needs to manually supply a value (steps for doing so are documented). Rather than having to specify an entire `colors` table, the user may use a single `bg` value for convenience.

![2023-06-15_15-18-44](https://github.com/HampusHauffman/block.nvim/assets/38332081/42d66208-b631-49c1-a210-92d0751b1fe6)
